### PR TITLE
Allow newer versions of react

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "webpack-dev-server": "3.9.0"
   },
   "peerDependencies": {
-    "react": "^16.12.0",
-    "create-subscription": "^16.12.0"
+    "react": ">=16.12.0",
+    "create-subscription": ">=16.12.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This seems to work fine with newer versions of react, but since the dependency range doesn't allow them, it adds to the wall of peer dependency warnings that yarn spits out when we run it.